### PR TITLE
Make sure /product gets mounted with write permissions.

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -24,7 +24,7 @@ is_mounted_rw() {
 
 mount_rw() {
   mount -o remount,rw $1
-  DID_MOUNT_RW=1
+  DID_MOUNT_RW=$1
 }
 
 unmount_rw() {


### PR DESCRIPTION
If /product is mounted early by the ROM, 'is_mounted /product' is true, but in a normal case, it's never mounted with write permissions.

This patch just checks to make sure that it's correctly mounted for writing, and returns it to it's previous state when finished.