### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Rebuild apk
       if: endsWith(github.ref, '/master')


### PR DESCRIPTION
v1 versions are deprecated.