### PR TITLE
Fix permission error when switching recents provider via --ch param

### DIFF
--- a/quickswitch
+++ b/quickswitch
@@ -237,9 +237,7 @@ switch_providers() {
 
   echo "\nThe overlay will be copied to $STEPDIR..."
 
-  if [ "$KSU" ]; then
-    APKPATH=$(pm path $1 | sed "s|package:||")
-  fi
+  APKPATH=$(pm path $1 | sed "s|package:||")
 
   # Create needed dirs
   while [ ! -d "$STEPDIR" ]; do

--- a/zipsigner
+++ b/zipsigner
@@ -15,7 +15,7 @@ if [ "$USER" == "root" ]; then
         cd "$(dirname "$0")"
         pwd
     )"
-    /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnodex2oat -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@" 2>/dev/null
+    /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnodex2oat -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@" 2>/dev/null \
  || /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@"
 else
     echo "zipsigner: need root permissions"


### PR DESCRIPTION
When using the -ch param in the terminal and rebooting the launcher crashed due to permission denial.
This was because the `privapp-permissions-x.xml` file was created with empty permissions.
The permissions were empty because APKPATH was empty for Magisk since the code is in an if block.

This PR removes that if block and fixes the `privapp-permissions-x.xml` file.

Also, the zipsigner had a small mistake which is also fixed in this.