### PR TITLE
Fixed installation script issues and Apatch support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QuickSwitch - Quickstep enabler for supported launchers
 
-QuickSwitch is a Magisk/KernelSU module which systemlessly allows supported launchers to access the recents (QuickStep) APIs
+QuickSwitch is a Magisk/KernelSU/Apatch module which systemlessly allows supported launchers to access the recents (QuickStep) APIs
 
 ![GitHub All Releases](https://img.shields.io/github/downloads/skittles9823/quickswitch/total?label=Downloads%20on%20GitHub)
 
@@ -16,7 +16,7 @@ QuickSwitch is a Magisk/KernelSU module which systemlessly allows supported laun
 
 ## Requirements:
 
-- Latest version of Magisk or KernelSU
+- Latest version of Magisk or KernelSU or Apatch
 - Android 9+
 
 ## Installation:
@@ -35,12 +35,11 @@ QuickSwitch is a Magisk/KernelSU module which systemlessly allows supported laun
 
 1. Install the latest QuickSwitch zip from the [Telegram channel](https://t.me/QuickstepSwitcherReleases) or [GitHub releases](https://github.com/skittles9823/QuickSwitch/releases).
 2. Open a terminal app and `su`
-3. if running on APatch you'll need to run this before step 4: `export KSU=true`
-4. run `/data/adb/modules/quickswitch/quickswitch --ch=launcher.package.name`
-5. Reboot.
-6. Verify your new recents provider is correct.
-7. Set the new recents provider as the default launcher.
-8. Profit.
+3. run `/data/adb/modules/quickswitch/quickswitch --ch=launcher.package.name`
+4. Reboot.
+5. Verify your new recents provider is correct.
+6. Set the new recents provider as the default launcher.
+7. Profit.
 
 ## Debugging:
 

--- a/customize.sh
+++ b/customize.sh
@@ -55,7 +55,7 @@ MODVER=$(grep_prop versionCode $MODULEDIR/module.prop)
 
 # Check for KSU
 if [ -z "$KSU" ]; then
-  sed -i "/KSU=true*/d" $MODDIR/quickswitch
+  sed -i "/KSU=true*/d" $MODPATH/quickswitch
 fi
 
 rm -rf /data/adb/modules/quickstepswitcher # yeet old module dir

--- a/customize.sh
+++ b/customize.sh
@@ -53,9 +53,13 @@ find /data/resource-cache/ -name "*QuickSwitchOverlay*" -exec rm -rf {} \;
 MODULEDIR="/data/adb/modules/$MODID"
 MODVER=$(grep_prop versionCode $MODULEDIR/module.prop)
 
-# Check for KSU
+# Check for root solution
 if [ -z "$KSU" ]; then
   sed -i "/KSU=true*/d" $MODPATH/quickswitch
+fi
+
+if [ -z "$APATCH" ]; then
+  sed -i "/APATCH=true*/d" $MODPATH/quickswitch
 fi
 
 rm -rf /data/adb/modules/quickstepswitcher # yeet old module dir

--- a/quickswitch
+++ b/quickswitch
@@ -10,9 +10,13 @@ ID="quickswitch"
 MODDIR=${0%/*}
 
 KSU=true # removed during install if false
+APATCH=true # removed during install if false
 
 if [ "$KSU" ]; then
   BBDIR="/data/adb/ksu/bin/busybox"
+elif [ "$APATCH" ]; then
+  BBDIR="/data/adb/ap/bin/busybox"
+  APATCH_VER=$(cat /data/adb/ap/version)
 else
   BBDIR="/data/adb/magisk/busybox"
 fi
@@ -120,10 +124,12 @@ get_logs() {
     set -o posix
     set
   ) >>$MODDIR/logs/$ID-vars.log
-  if [ -z "$KSU" ]; then
+  if [ -z "$KSU" ] && [ -z "$APATCH" ]; then
     echo -e "\n---Magisk Version---" >>$MODDIR/logs/$ID-vars.log
     echo $(grep "MAGISK_VER_CODE=" /data/adb/magisk/util_functions.sh |
       sed "s/MAGISK_VER_CODE/MagiskVersion/") >>$MODDIR/logs/$ID-vars.log
+  elif [ "$APATCH" ]; then
+    echo -e "\n---APATCH Version---\nAPVersion=$APATCH_VER" >>$MODDIR/logs/$ID-vars.log
   else
     echo -e "\n---KSU Version---\nKSUVersion=$KSU_VER" >>$MODDIR/logs/$ID-vars.log
   fi
@@ -159,7 +165,7 @@ setvars() {
       ;;
     *)
       PRODUCT=true
-      if [ -z "$KSU" ]; then
+      if [ -z "$KSU" ] && [-z "$APATCH" ]; then
         # Yay, magisk supports bind mounting /product now
         MAGISK_VER_CODE=$(grep "MAGISK_VER_CODE=" /data/adb/magisk/util_functions.sh | awk -F = '{ print $2 }')
         if [ $MAGISK_VER_CODE -ge "20000" ]; then
@@ -215,7 +221,7 @@ reset_provider() {
     rm -rf $STEPDIR/QuickSwitchOverlay.apk
   fi
   rm -rf $MODDIR/system
-  if [ "$KSU" ]; then
+  if [ "$KSU" ] || [ "$APATCH" ] ; then
     [ -d $MODDIR/product ] && rm -rf $MODDIR/product
     [ -d $MODDIR/vendor ] && rm -rf $MODDIR/vendor
   fi
@@ -237,7 +243,7 @@ switch_providers() {
 
   echo "\nThe overlay will be copied to $STEPDIR..."
 
-  if [ "$KSU" ]; then
+  if [ "$KSU" ] || [ "$APATCH" ]; then
     APKPATH=$(pm path $1 | sed "s|package:||")
   fi
 

--- a/quickswitch
+++ b/quickswitch
@@ -138,7 +138,7 @@ get_logs() {
 }
 
 setvars() {
-  [ $KSU ] && STEPDIRPREFIX=$MODDIR || STEPDIRPREFIX=$MODDIR/system
+  STEPDIRPREFIX=$MODDIR/system
   SUFFIX="/overlay/QuickSwitchOverlay"
   if [ "$API" -ge 29 ]; then
     STEPDIR=$STEPDIRPREFIX/product$SUFFIX

--- a/quickswitch
+++ b/quickswitch
@@ -165,7 +165,7 @@ setvars() {
       ;;
     *)
       PRODUCT=true
-      if [ -z "$KSU" ] && [-z "$APATCH" ]; then
+      if [ -z "$KSU" ] && [ -z "$APATCH" ]; then
         # Yay, magisk supports bind mounting /product now
         MAGISK_VER_CODE=$(grep "MAGISK_VER_CODE=" /data/adb/magisk/util_functions.sh | awk -F = '{ print $2 }')
         if [ $MAGISK_VER_CODE -ge "20000" ]; then

--- a/zipsigner
+++ b/zipsigner
@@ -15,8 +15,8 @@ if [ "$USER" == "root" ]; then
         cd "$(dirname "$0")"
         pwd
     )"
-    /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnodex2oat -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@" 2>/dev/null
- || /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@"
+    /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnodex2oat -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@" 2>/dev/null \
+ || /apex/com.android.art/bin/dalvikvm -Djava.io.tmpdir=. -Xnoimage-dex2oat -cp $dir/zipsigner-*.jar com.topjohnwu.utils.ZipSigner "$@";
 else
     echo "zipsigner: need root permissions"
 fi


### PR DESCRIPTION
Contains #53.

1. Script issue.
Since $MODDIR is empty, ````KSU=true```` cannot be deleted correctly if KSU does not exist.
This causes the script to perform processing for KSU regardless of the presence or absence of ksu.

2. APATCH support
Added conditional branching that supports APATCH.
I remember that APM had the same specifications as the KSU module, so I decided to follow the processing of KSU except for the busybox path.

I have a limited understanding of git and shell scripts, so please feel free to let me know if there is anything I'm missing.