### PR TITLE
 Support for split APKs

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -27,15 +27,8 @@ if [ $MIUI ] && [ $API -lt "30" ]; then
 fi
 ui_print "- Extracting module files"
 
-unzip -o "$ZIPFILE" 'overlays/*' 'system/*' 'common/*' 'module.prop' 'system.prop' 'sepolicy.rule' 'zipsigner*' 'uninstall.sh' 'quickswitch' 'service.sh' -d $MODPATH >&2
+unzip -o "$ZIPFILE" 'overlays/*' 'system/*' 'common/*' 'module.prop' 'system.prop' 'sepolicy.rule' 'zipsigner*' 'uninstall.sh' 'quickswitch' 'service.sh' 'webroot/*' -d $MODPATH >&2
 chmod +x $MODPATH/common/*
-
-if [ -z "$NOAPK" ]; then
-  unzip -o "$ZIPFILE" 'QuickSwitch.apk' -d /data/local/tmp >&2
-  ui_print "- installing QuickSwitch.apk"
-  pm install -r "/data/local/tmp/QuickSwitch.apk"
-  rm -rf /data/local/tmp/QuickSwitch.apk
-fi
 
 AAPT2=aapt2_$(getprop ro.product.cpu.abi)
 cp -af $MODPATH/common/$AAPT2 $MODPATH/aapt2 || abort "Unsupported Arch!"
@@ -58,6 +51,17 @@ fi
 
 if [ -z "$APATCH" ]; then
   sed -i "/APATCH=true*/d" $MODPATH/quickswitch
+fi
+
+if [ -n "$KSU" ] || [ -n "$APATCH" ]; then
+  NOAPK=true
+fi
+
+if [ -z "$NOAPK" ]; then
+  unzip -o "$ZIPFILE" 'QuickSwitch.apk' -d /data/local/tmp >&2
+  ui_print "- installing QuickSwitch.apk"
+  pm install -r "/data/local/tmp/QuickSwitch.apk"
+  rm -rf /data/local/tmp/QuickSwitch.apk
 fi
 
 rm -rf /data/adb/modules/quickstepswitcher # yeet old module dir

--- a/module.prop
+++ b/module.prop
@@ -3,5 +3,5 @@ name=QuickSwitch
 version=v4.0.3
 versionCode=4030
 author=The Lawnchair team
-description=Quickstep enabler for supported launchers
+description=[ Quickstep : Default ] Quickstep enabler for supported launchers
 updateJson=https://raw.githubusercontent.com/skittles9823/QuickSwitch/master/QuickSwitch.json

--- a/quickswitch
+++ b/quickswitch
@@ -232,6 +232,7 @@ reset_provider() {
   rm -rf /data/resource-cache/overlays.list
   find /data/resource-cache/ -name "*QuickstepSwitcherOverlay*" -exec rm -rf {} \;
   find /data/resource-cache/ -name "*QuickSwitchOverlay*" -exec rm -rf {} \;
+  sed -i 's/\(description=\[ Quickstep : \)[^]]*\]/\1Default ]/' $MODDIR/module.prop
 }
 
 unmount_rw_stepdir() {
@@ -326,6 +327,7 @@ $permissions
 
   if [ -s ${STEPDIR}/QuickSwitchOverlay.apk ]; then
     echo "\nOverlay successfully copied..."
+    sed -i "s/\(description=\[ Quickstep : \)[^]]*\]/\1✅$1 ]/" $MODDIR/module.prop
   else
     abortexit "The overlay was not copied, please send logs to the developer."
   fi

--- a/quickswitch
+++ b/quickswitch
@@ -248,7 +248,7 @@ switch_providers() {
   echo "\nThe overlay will be copied to $STEPDIR..."
 
   if [ "$KSU" ] || [ "$APATCH" ]; then
-    APKPATH=$(pm path $1 | sed "s|package:||")
+    APKPATH=$(pm path $1 | sed "s|package:||" | sed -n '/base\.apk/p' )
   fi
 
   # Create needed dirs

--- a/quickswitch
+++ b/quickswitch
@@ -9,7 +9,7 @@ ID="quickswitch"
 # Mod Directory
 MODDIR=${0%/*}
 
-KSU=true    # removed during install if false
+KSU=true # removed during install if false
 APATCH=true # removed during install if false
 
 if [ "$KSU" ]; then
@@ -147,7 +147,7 @@ setvars() {
   if [ -n "$KSU" ] || [ -n "$APATCH" ]; then
     STEPDIRPREFIX=$MODDIR
   else
-    STEPDIRPREFIX=$MODDIR/system
+     STEPDIRPREFIX=$MODDIR/system
   fi
   SUFFIX="/overlay/QuickSwitchOverlay"
   if [ "$API" -ge 29 ]; then
@@ -225,7 +225,7 @@ reset_provider() {
     rm -rf $STEPDIR/QuickSwitchOverlay.apk
   fi
   rm -rf $MODDIR/system
-  if [ "$KSU" ] || [ "$APATCH" ]; then
+  if [ "$KSU" ] || [ "$APATCH" ] ; then
     [ -d $MODDIR/product ] && rm -rf $MODDIR/product
     [ -d $MODDIR/vendor ] && rm -rf $MODDIR/vendor
   fi
@@ -247,9 +247,7 @@ switch_providers() {
 
   echo "\nThe overlay will be copied to $STEPDIR..."
 
-  if [ "$KSU" ] || [ "$APATCH" ]; then
-    APKPATH=$(pm path $1 | sed "s|package:||" | sed -n '/base\.apk/p' )
-  fi
+  APKPATH=$(pm path $1 | sed "s|package:||" | sed -n '/base\.apk/p' )
 
   # Create needed dirs
   while [ ! -d "$STEPDIR" ]; do
@@ -311,8 +309,8 @@ $permissions
   mkdir ${MODDIR}/compiled
   aapt2 compile -v --dir ${OVERLAYDIR}/overlay/ -o ${MODDIR}/compiled && \
     aapt2 link -o ${MODDIR}/unsigned.apk -I /system/framework/framework-res.apk \
-      --manifest ${OVERLAYDIR}/AndroidManifest.xml ${MODDIR}/compiled/* \
-      &>$MODDIR/logs/aapt2.log
+    --manifest ${OVERLAYDIR}/AndroidManifest.xml ${MODDIR}/compiled/* \
+    &>$MODDIR/logs/aapt2.log
   rm -rf ${MODDIR}/compiled
 
   if [ -s ${MODDIR}/unsigned.apk ]; then


### PR DESCRIPTION
The Google Play version of Lawnchair uses split APKs, so executing ```pm path``` returns multiple paths, making it difficult to handle properly. I have added a process to extract only the path to base.apk.
This change has been tested with Apatch + Termux.

command:```su -c /data/adb/modules/quickswitch/quickswitch --ch=app.lawnchair.play```


Also, the QuickSwitch app has not been updated in a long time, so the possibility of Magisk users using the script should be considered.